### PR TITLE
Don't use Vec::from_raw_parts

### DIFF
--- a/xpc-connection/src/message.rs
+++ b/xpc-connection/src/message.rs
@@ -79,6 +79,13 @@ pub fn xpc_object_to_xpctype(xpc_object: xpc_object_t) -> (XpcType, xpc_object_t
     panic!("Unknown `xpc` object type!")
 }
 
+unsafe fn copy_raw_to_vec(ptr: *const u8, length: usize) -> Vec<u8> {
+    let mut vec = Vec::with_capacity(length);
+    vec.set_len(length);
+    std::ptr::copy_nonoverlapping(ptr, vec.as_mut_ptr(), length);
+    vec
+}
+
 #[derive(Debug, Clone)]
 pub enum Message {
     Int64(i64),
@@ -142,12 +149,12 @@ pub fn xpc_object_to_message(xpc_object: xpc_object_t) -> Message {
         XpcType::Data => unsafe {
             let ptr = xpc_data_get_bytes_ptr(xpc_object) as *mut u8;
             let length = xpc_data_get_length(xpc_object);
-            Message::Data(Vec::from_raw_parts(ptr, length, length))
+            Message::Data(copy_raw_to_vec(ptr, length))
         },
         XpcType::Uuid => unsafe {
             let ptr = xpc_uuid_get_bytes(xpc_object) as *mut u8;
             let length = mem::size_of::<uuid_t>();
-            Message::Uuid(Vec::from_raw_parts(ptr, length, length))
+            Message::Uuid(copy_raw_to_vec(ptr, length))
         },
         XpcType::Error => {
             // TODO: Figure out how to return more specific error messages...


### PR DESCRIPTION
It has extremely strict restrictions that we can't fullfil.

More importantly, we don't own the data given to us, so once we take the value and drop it, it causes a crash when libdispatch attempts to free a NULL pointer. I'm on macOS 10.15.3 in case you're unable to reproduce it.

Most of the time it fails like this:
```
running 1 test
Got data! Ok(Dictionary({"kCBMsgArgs": Dictionary({"kCBAdvDataDeviceAddress": Data([255, 255, 255, 255, 255, 255])}), "kCBMsgId": Int64(42)}))
integration_test-e211cc896451940c(79566,0x700003cfa000) malloc: *** error for object 0x7ff864c04d90: pointer being freed was not allocated
integration_test-e211cc896451940c(79566,0x700003cfa000) malloc: *** set a breakpoint in malloc_error_break to debug
```
But other times I have seen it segfault.

After fixing this, I now see the second assertion fail:
```
    // Can't get data when the channel is closed by dropping `xpc_connection`
    xpc_connection.send_message(message);
    drop(xpc_connection);
    assert!(blocking_stream.next().is_none());
```

Is this test valid? `XpcConnection::connect` returns a clone of the UnboundReceiver, so I'm not sure that the connection being dropped should cause the clone to be unusable.