### PR TITLE
Use the futures crate

### DIFF
--- a/xpc-connection/Cargo.toml
+++ b/xpc-connection/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["os", "api-bindings", "concurrency", "encoding"]
 
 [dependencies]
 block = "0.1.6"
-futures-preview = "0.2.2"
+futures = "0.3.4"
 xpc-connection-sys = { path="../xpc-connection-sys", version="0.1.0" }


### PR DESCRIPTION
It looks like futures-preview has served its purpose and futures 0.3 continues in the futures crate.