### PR TITLE
Enable CI builds for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,14 @@
-branches:
-  only:
-  - master
 language: rust
-rust:
-  - stable
 cache:
   cargo: true
-matrix:
-  # https://docs.travis-ci.com/user/reference/osx/#os-x-version
-  include:
-    - os: osx # 10.14
-      osx_image: xcode11.3
-    - os: osx # 10.13
-      osx_image: xcode10.1
-  allow_failures:
-    - os: osx # 10.12
-      osx_image: xcode9.2
+rust:
+- nightly
+- stable
+os: osx
+osx_image:
+- xcode12.2 # macOS 10.15.7
+- xcode11.3 # macOS 10.14.6
+- xcode10.1 # macOS 10.13
 before_install:
   - rustup component add clippy rustfmt
 script:

--- a/xpc-connection/src/lib.rs
+++ b/xpc-connection/src/lib.rs
@@ -39,7 +39,7 @@ impl XpcConnection {
         }
     }
 
-    pub fn connect(self: &mut Self) -> UnboundedReceiver<Message> {
+    pub fn connect(&mut self) -> UnboundedReceiver<Message> {
         // Start a connection
         let connection = {
             let service_name_cstring =
@@ -83,7 +83,7 @@ impl XpcConnection {
         unbounded_receiver
     }
 
-    pub fn send_message(self: &Self, message: Message) {
+    pub fn send_message(&self, message: Message) {
         let xpc_object = message_to_xpc_object(message);
         unsafe {
             xpc_connection_send_message(self.connection.unwrap(), xpc_object);


### PR DESCRIPTION
This also updates the versions of macOS and rust we test against and fixes a couple of Clippy warnings so the builds pass.