### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-10.15, macos-11.0 ]
+        os: [ macos-11, macos-12, macos-13 ]
         rust: [ nightly, stable ]
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
+      - name: Install the toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
+      - name: Install the stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/examples/echo-server/Makefile
+++ b/examples/echo-server/Makefile
@@ -4,6 +4,8 @@ all: ../../target/debug/echo-server
 	cargo build
 
 install: ../../target/debug/echo-server
+	# GitHub's runners don't have this directory by default.
+	sudo mkdir -p /Library/PrivilegedHelperTools/
 	sudo cp ../../target/debug/echo-server /Library/PrivilegedHelperTools/com.example.echo
 	sudo cp com.example.echo.plist /Library/LaunchDaemons/
 	sudo launchctl load /Library/LaunchDaemons/com.example.echo.plist


### PR DESCRIPTION
The macOS runner labels needed updating. https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Also for some reason GitHub's macOS runners don't come with the `/Library/PrivilegedHelperTools` directory. I was pretty sure this was in the base installation by default.